### PR TITLE
Update installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,13 +11,14 @@ You can invite the bot to your server using this link: https://projectlounge.pw/
 
 A command list can be found [here](https://projectlounge.pw/esmBot/help.html).
 
-The bot is only supported on Linux/Unix-like operating systems. If you want to run it locally for testing purposes, you should install ImageMagick (version >=7), FFmpeg, PostgreSQL, and the Microsoft core fonts:
+The bot is only supported on Linux/Unix-like operating systems. If you want to run it locally for testing purposes, you should install ImageMagick (version >=7), FFmpeg, PostgreSQL, libstb and the Microsoft core fonts:
 
 ```shell
 # On most Debian/Ubuntu-based distros you will need to build ImageMagick from source instead of installing from apt/similar package managers.
 # Instructions to do so can be found here: https://imagemagick.org/script/install-source.php
-sudo apt-get install imagemagick ffmpeg postgresql ttf-mscorefonts-installer
+sudo apt-get install imagemagick ffmpeg postgresql ttf-mscorefonts-installer libstb-dev
 ```
+You'll also need to build and install [zxing-cpp](https://github.com/nu-book/zxing-cpp) from source.
 
 After that, you should install the rest of the dependencies using npm:
 


### PR DESCRIPTION
It appears libstb and zxing-cpp are required (for the QR module, at least on master; looks like they're actually not required for the current release), but were not included in the dependencies.